### PR TITLE
Implement Duffel travel booking flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## Travel booking setup
+
+Set the Duffel access token before running the development server:
+
+```bash
+export DUFFEL_ACCESS_TOKEN="duffel_live_xxx"
+```
+
+The Travel page (`/travel`) now uses Duffel’s API to search, review, and book flights end to end.

--- a/src/app/api/travel/book/route.ts
+++ b/src/app/api/travel/book/route.ts
@@ -1,0 +1,123 @@
+import {NextResponse} from 'next/server';
+import {getDuffelClient} from '@/lib/duffel';
+import {applyMarkup} from '@/lib/travel';
+
+type PassengerPayload = {
+  id?: string;
+  type?: string;
+  title?: string;
+  given_name?: string;
+  family_name?: string;
+  born_on?: string;
+  email?: string;
+  phone_number?: string;
+};
+
+type ContactPayload = {
+  email?: string;
+  phone_number?: string;
+};
+
+type BookPayload = {
+  offerId?: string;
+  passengers?: PassengerPayload[];
+  contact?: ContactPayload;
+};
+
+function cleanPassenger(passenger: PassengerPayload, index: number) {
+  const title = passenger.title?.toLowerCase() || 'mr';
+  return {
+    id: passenger.id || `pas_${index + 1}`,
+    type: (passenger.type || 'adult') as 'adult',
+    title,
+    given_name: passenger.given_name?.trim(),
+    family_name: passenger.family_name?.trim(),
+    born_on: passenger.born_on,
+    email: passenger.email,
+    phone_number: passenger.phone_number,
+  };
+}
+
+function validatePassenger(passenger: ReturnType<typeof cleanPassenger>) {
+  return (
+    Boolean(passenger.given_name) &&
+    Boolean(passenger.family_name) &&
+    Boolean(passenger.born_on) &&
+    Boolean(passenger.email) &&
+    Boolean(passenger.phone_number)
+  );
+}
+
+function validateContact(contact?: ContactPayload | null) {
+  if (!contact) return false;
+  return Boolean(contact.email) && Boolean(contact.phone_number);
+}
+
+export async function POST(req: Request) {
+  try {
+    const body: BookPayload = await req.json();
+    const offerId = body.offerId?.toString();
+    const rawPassengers = body.passengers ?? [];
+    const contact = body.contact;
+
+    if (!offerId) {
+      return NextResponse.json({error: 'offerId is required'}, {status: 400});
+    }
+
+    if (!rawPassengers.length) {
+      return NextResponse.json({error: 'At least one passenger is required'}, {status: 400});
+    }
+
+    if (!validateContact(contact)) {
+      return NextResponse.json(
+        {error: 'A contact email and phone number are required'},
+        {status: 400},
+      );
+    }
+
+    const passengers = rawPassengers
+      .map(cleanPassenger)
+      .filter(passenger => validatePassenger(passenger));
+
+    if (!passengers.length) {
+      return NextResponse.json(
+        {error: 'Passenger details are incomplete'},
+        {status: 400},
+      );
+    }
+
+    const duffel = getDuffelClient();
+    const freshOffer = await duffel.offers.get(offerId);
+
+    const order = await duffel.orders.create({
+      type: 'instant',
+      selected_offers: [offerId],
+      passengers,
+      contact: {
+        email: contact?.email!,
+        phone_number: contact?.phone_number!,
+      },
+      payments: [
+        {
+          type: 'balance',
+          amount: Number(freshOffer.data.total_amount).toFixed(2),
+          currency: freshOffer.data.total_currency,
+        },
+      ],
+    });
+
+    const pricing = applyMarkup(freshOffer.data, passengers.length).pricing;
+
+    return NextResponse.json({
+      order_id: order.data.id,
+      booking_reference: order.data.booking_reference,
+      status: order.data.status,
+      documents: order.data.documents ?? [],
+      pricing,
+    });
+  } catch (error: any) {
+    console.error('Booking failed', error);
+    const errorPayload = error?.errors ?? error?.message ?? 'Booking failed';
+    return NextResponse.json({error: errorPayload}, {status: 500});
+  }
+}

--- a/src/app/api/travel/offers/[id]/route.ts
+++ b/src/app/api/travel/offers/[id]/route.ts
@@ -1,0 +1,36 @@
+import {NextResponse} from 'next/server';
+import {getDuffelClient} from '@/lib/duffel';
+import {summariseOffer} from '@/lib/travel';
+
+type Params = {
+  params: {id: string};
+};
+
+export async function GET(req: Request, {params}: Params) {
+  const offerId = params.id;
+
+  if (!offerId) {
+    return NextResponse.json({error: 'Offer id is required'}, {status: 400});
+  }
+
+  try {
+    const {searchParams} = new URL(req.url);
+    const pax = Math.max(1, Number(searchParams.get('pax') ?? '1'));
+
+    const duffel = getDuffelClient();
+    const offer = await duffel.offers.get(offerId, {
+      return_available_services: true,
+    });
+
+    return NextResponse.json({
+      offer: summariseOffer(offer.data, pax),
+      available_services: offer.data.available_services ?? [],
+    });
+  } catch (error: any) {
+    console.error('Load offer failed', error);
+    return NextResponse.json(
+      {error: error?.message ?? 'Unable to load offer'},
+      {status: 500},
+    );
+  }
+}

--- a/src/app/api/travel/search/route.ts
+++ b/src/app/api/travel/search/route.ts
@@ -1,0 +1,90 @@
+import {NextResponse} from 'next/server';
+import {getDuffelClient} from '@/lib/duffel';
+import {summariseOffer} from '@/lib/travel';
+
+type SearchPayload = {
+  origin?: string;
+  destination?: string;
+  departureDate?: string;
+  returnDate?: string | null;
+  adults?: number;
+  cabinClass?: string;
+};
+
+function normaliseLocation(value?: string | null) {
+  return value?.toString().trim().toUpperCase() ?? '';
+}
+
+function isValidDate(value?: string | null) {
+  if (!value) return false;
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+export async function POST(req: Request) {
+  try {
+    const body: SearchPayload = await req.json();
+    const origin = normaliseLocation(body.origin);
+    const destination = normaliseLocation(body.destination);
+    const departureDate = body.departureDate?.toString();
+    const returnDate = body.returnDate?.toString() || null;
+    const adults = Math.max(1, Number(body.adults ?? 1));
+    const cabinClass = (body.cabinClass ?? 'economy').toString();
+
+    if (!origin || !destination || !departureDate) {
+      return NextResponse.json(
+        {error: 'origin, destination and departureDate are required'},
+        {status: 400},
+      );
+    }
+
+    if (!isValidDate(departureDate) || (returnDate && !isValidDate(returnDate))) {
+      return NextResponse.json(
+        {error: 'Invalid date format. Use YYYY-MM-DD.'},
+        {status: 400},
+      );
+    }
+
+    const duffel = getDuffelClient();
+
+    const slices = [
+      {
+        origin,
+        destination,
+        departure_date: departureDate,
+      },
+    ];
+
+    if (returnDate) {
+      slices.push({
+        origin: destination,
+        destination: origin,
+        departure_date: returnDate,
+      });
+    }
+
+    const passengers = Array.from({length: adults}).map(() => ({type: 'adult' as const}));
+
+    const offerRequest = await duffel.offerRequests.create({
+      slices,
+      passengers,
+      cabin_class: cabinClass,
+      return_offers: true,
+    });
+
+    const offers = (offerRequest.data.offers ?? []).map(offer =>
+      summariseOffer(offer, adults),
+    );
+
+    return NextResponse.json({
+      offerRequestId: offerRequest.data.id,
+      passengers: adults,
+      offers,
+    });
+  } catch (error: any) {
+    console.error('Duffel search failed', error);
+    return NextResponse.json(
+      {error: error?.message ?? 'Unable to search flights right now.'},
+      {status: 500},
+    );
+  }
+}

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,95 +1,497 @@
 "use client";
-import { useEffect, useState } from "react";
+
+import {ChangeEvent, FormEvent, useEffect, useMemo, useState} from "react";
 import Header from "@/components/header";
 import Footer from "@/components/footer";
+import type {OfferSummary, SegmentSummary} from "@/lib/travel";
 
-export default function Checkout({ searchParams }: { searchParams: { offer: string } }) {
-  const [offer, setOffer] = useState<any>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const offerId = searchParams.offer;
+type PassengerForm = {
+  title: string;
+  given_name: string;
+  family_name: string;
+  born_on: string;
+  email: string;
+  phone_number: string;
+};
+
+type ContactForm = {
+  email: string;
+  phone_number: string;
+};
+
+const formatter = new Intl.DateTimeFormat("en", {
+  weekday: "short",
+  month: "short",
+  day: "2-digit",
+  hour: "numeric",
+  minute: "numeric",
+});
+
+function formatDate(value?: string | null) {
+  if (!value) return "";
+  try {
+    return formatter.format(new Date(value));
+  } catch (error) {
+    return value ?? "";
+  }
+}
+
+function formatDuration(duration?: string | null) {
+  if (!duration) return "";
+  const match = duration.match(/PT(?:(\d+)H)?(?:(\d+)M)?/);
+  if (!match) return duration;
+  const [, hours, minutes] = match;
+  const parts: string[] = [];
+  if (hours) parts.push(`${hours}h`);
+  if (minutes) parts.push(`${minutes}m`);
+  return parts.join(" ");
+}
+
+function segmentKey(segment: SegmentSummary, index: number) {
+  return segment.id || `${segment.marketing_flight}-${index}`;
+}
+
+function createPassengerForms(count: number): PassengerForm[] {
+  return Array.from({length: count}).map(() => ({
+    title: "mr",
+    given_name: "",
+    family_name: "",
+    born_on: "",
+    email: "",
+    phone_number: "",
+  }));
+}
+
+type CheckoutProps = {
+  searchParams: {
+    offer?: string;
+    pax?: string;
+  };
+};
+
+export default function Checkout({searchParams}: CheckoutProps) {
+  const offerId = searchParams.offer ?? "";
+  const passengerCount = useMemo(
+    () => Math.max(1, Number(searchParams.pax ?? "1")),
+    [searchParams.pax],
+  );
+
+  const [offer, setOffer] = useState<OfferSummary | null>(null);
+  const [loadingOffer, setLoadingOffer] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [passengers, setPassengers] = useState<PassengerForm[]>(() =>
+    createPassengerForms(passengerCount),
+  );
+  const [contact, setContact] = useState<ContactForm>({email: "", phone_number: ""});
+  const [booking, setBooking] = useState(false);
+  const [bookingError, setBookingError] = useState<string | null>(null);
+  const [bookingResult, setBookingResult] = useState<any>(null);
+
+  useEffect(() => {
+    if (!offerId) {
+      setLoadError("No offer selected. Please return to the travel search.");
+      setOffer(null);
+    }
+  }, [offerId]);
+
+  useEffect(() => {
+    setPassengers(prev => {
+      if (prev.length === passengerCount) return prev;
+      return createPassengerForms(passengerCount);
+    });
+  }, [passengerCount]);
 
   useEffect(() => {
     if (!offerId) return;
-    setLoading(true);
-    setError(null);
-    fetch(process.env.NEXT_PUBLIC_API_URL + "/api/offers/" + offerId)
-      .then(r => {
-        if (!r.ok) throw new Error('Failed to load offer details.');
-        return r.json();
+    setLoadingOffer(true);
+    setLoadError(null);
+    fetch(`/api/travel/offers/${offerId}?pax=${passengerCount}`)
+      .then(response => {
+        if (!response.ok) {
+          return response.json().then(body => {
+            throw new Error(body?.error || "Failed to load offer details");
+          });
+        }
+        return response.json();
       })
-      .then(setOffer)
-      .catch(err => setError(err.message))
-      .finally(() => setLoading(false));
-  }, [offerId]);
+      .then(data => {
+        setOffer(data.offer);
+      })
+      .catch(error => {
+        console.error(error);
+        setLoadError(error.message || "Unable to load offer details.");
+      })
+      .finally(() => setLoadingOffer(false));
+  }, [offerId, passengerCount]);
 
-  async function book() {
-    setLoading(true);
-    setError(null);
-    // This is hardcoded for the demo as per the user's blueprint.
-    // In a real app, you would collect this information from the user.
-    const passengers = [{
-      type: "adult",
-      title: "mr",
-      given_name: "John",
-      family_name: "Doe",
-      born_on: "1990-05-12",
-      email: "john.doe@example.com", // Ensure a valid email
-      phone_number: "+14165550123"
-    }];
+  const missingPassengerDetails = passengers.some(passenger =>
+    !passenger.given_name ||
+    !passenger.family_name ||
+    !passenger.born_on ||
+    !passenger.email ||
+    !passenger.phone_number,
+  );
 
-    const contact = { email: "john.doe@example.com", phone_number: "+14165550123" };
+  const missingContact = !contact.email || !contact.phone_number;
+
+  const canSubmit = !missingPassengerDetails && !missingContact && !booking && !loadingOffer && !!offer;
+
+  function updatePassenger(index: number, field: keyof PassengerForm, value: string) {
+    setPassengers(prev =>
+      prev.map((passenger, idx) =>
+        idx === index
+          ? {
+              ...passenger,
+              [field]: value,
+            }
+          : passenger,
+      ),
+    );
+  }
+
+  function onPassengerChange(index: number, field: keyof PassengerForm) {
+    return (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+      const value = event.currentTarget.value;
+      updatePassenger(index, field, value);
+      if (index === 0 && (field === "email" || field === "phone_number")) {
+        setContact(prev => ({
+          ...prev,
+          [field]: prev[field] ? prev[field] : value,
+        }));
+      }
+    };
+  }
+
+  async function book(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!offer || !canSubmit) return;
+
+    setBooking(true);
+    setBookingError(null);
+    setBookingResult(null);
 
     try {
-        const r = await fetch(process.env.NEXT_PUBLIC_API_URL + "/api/book-with-balance", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ offer_id: offerId, passengers, contact }),
-        });
-        const data = await r.json();
-        if (data.error) {
-            // This will catch errors from the Duffel API like "invalid_passenger_name"
-            const errorMessage = typeof data.error === 'object' ? JSON.stringify(data.error) : data.error;
-            throw new Error(errorMessage);
-        }
-        alert(data.order ? "Booked! Order " + data.order.id : "Booking failed");
-    } catch (error: any) {
-        console.error(error);
-        setError(`Booking failed: ${error.message}`);
-    } finally {
-        setLoading(false);
-    }
-  }
-  
-  const renderContent = () => {
-    if (loading && !offer) return <p className="text-center">Loading offer details...</p>;
-    if (error) return <p className="text-center text-red-500">{error}</p>;
-    if (!offer) return <p className="text-center">Offer not found or invalid.</p>;
+      const payload = {
+        offerId,
+        passengers: passengers.map((passenger, index) => ({
+          id: `pas_${index + 1}`,
+          type: "adult",
+          title: passenger.title,
+          given_name: passenger.given_name,
+          family_name: passenger.family_name,
+          born_on: passenger.born_on,
+          email: passenger.email,
+          phone_number: passenger.phone_number,
+        })),
+        contact,
+      };
 
-    return (
-        <div className="border p-6 rounded-lg bg-card shadow-lg">
-          <div className="mb-4">
-            <h2 className="text-xl font-semibold">Offer Details</h2>
-            <p className="text-muted-foreground">Offer ID: {offerId}</p>
-          </div>
-          <div className="text-2xl font-bold font-headline mb-6">
-            Total Price: {offer.pricing.display_total_amount} {offer.pricing.currency}
-          </div>
-          <p className="text-sm text-muted-foreground mb-6">You are about to book a flight with a hardcoded passenger, "John Doe". The booking will be made using the Duffel Balance method.</p>
-          {error && <div className="text-red-500 mb-4 p-3 border border-red-500 bg-red-50 rounded-md">{error}</div>}
-          <button onClick={book} disabled={loading} className="w-full bg-primary text-primary-foreground p-3 rounded-md h-12 flex items-center justify-center font-semibold text-lg disabled:bg-primary/70">
-            {loading ? 'Booking...' : 'Confirm & Book'}
-            </button>
-        </div>
-    );
+      const response = await fetch("/api/travel/book", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({error: "Booking failed"}));
+        const {error} = body;
+        let message = "Booking failed. Please review passenger details.";
+        if (typeof error === "string") {
+          message = error;
+        } else if (Array.isArray(error) && error.length) {
+          message = error[0]?.message ?? message;
+        }
+        throw new Error(message);
+      }
+
+      const data = await response.json();
+      setBookingResult(data);
+    } catch (error: any) {
+      console.error(error);
+      setBookingError(error?.message ?? "Booking failed. Please try again.");
+    } finally {
+      setBooking(false);
+    }
   }
 
   return (
     <div className="flex flex-col min-h-screen">
       <Header />
-      <main className="p-6 max-w-2xl mx-auto pt-24 w-full">
-        <h1 className="text-3xl font-headline font-bold mb-6">Confirm Your Booking</h1>
-        {renderContent()}
+      <main className="px-6 pb-24 pt-24 w-full">
+        <section className="max-w-4xl mx-auto space-y-8">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-headline font-bold">Confirm your booking</h1>
+            <p className="text-muted-foreground">
+              Enter traveller details exactly as they appear on passports. We’ll reserve your seats using
+              our Duffel agency credentials.
+            </p>
+          </div>
+
+          {loadError && (
+            <div className="border border-destructive/50 bg-destructive/10 text-destructive rounded-lg p-4">
+              {loadError}
+            </div>
+          )}
+
+          {offer && (
+            <div className="border border-border rounded-xl bg-card shadow-md p-6 space-y-4">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-sm uppercase tracking-wide text-muted-foreground">
+                    {offer.owner?.iata_code}
+                  </p>
+                  <h2 className="text-xl font-semibold">{offer.owner?.name ?? "Selected flight"}</h2>
+                  <p className="text-sm text-muted-foreground">Travellers: {passengerCount}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-sm text-muted-foreground">Total including concierge fee</p>
+                  <p className="text-3xl font-headline font-bold">
+                    {offer.pricing.display_total_amount} {offer.pricing.currency}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Airline fare {offer.pricing.base_total_amount} + {offer.pricing.markup_total}
+                  </p>
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                {offer.slices.map(slice => (
+                  <div key={slice.id} className="rounded-lg border border-border/60 bg-muted/20 p-4">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                      <p className="font-medium">
+                        {slice.origin} → {slice.destination}
+                      </p>
+                      <span className="text-sm text-muted-foreground">{formatDuration(slice.duration)}</span>
+                    </div>
+                    <ol className="mt-3 space-y-3">
+                      {slice.segments.map((segment, index) => (
+                        <li key={segmentKey(segment, index)} className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                          <div>
+                            <p className="font-semibold">
+                              {formatDate(segment.departing_at)} → {formatDate(segment.arriving_at)}
+                            </p>
+                            <p className="text-sm text-muted-foreground">
+                              {segment.origin} to {segment.destination}
+                            </p>
+                          </div>
+                          <div className="text-sm text-muted-foreground text-right">
+                            <p>{segment.carrier_name}</p>
+                            {segment.marketing_flight && <p>{segment.marketing_flight}</p>}
+                          </div>
+                        </li>
+                      ))}
+                    </ol>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <form onSubmit={book} className="border border-border rounded-xl bg-card shadow-md p-6 space-y-6">
+            <div>
+              <h2 className="text-xl font-semibold">Passenger information</h2>
+              <p className="text-sm text-muted-foreground">
+                We require a valid email and phone number for each traveller in case the airline needs to
+                reach you.
+              </p>
+            </div>
+
+            <div className="space-y-6">
+              {passengers.map((passenger, index) => (
+                <div key={index} className="rounded-lg border border-border/60 bg-muted/10 p-4 space-y-4">
+                  <div className="flex items-center justify-between">
+                    <h3 className="font-medium">Traveller {index + 1}</h3>
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                    <div className="flex flex-col">
+                      <label htmlFor={`title-${index}`} className="text-sm text-muted-foreground mb-1">
+                        Title
+                      </label>
+                      <select
+                        id={`title-${index}`}
+                        className="border border-input bg-background rounded-md px-3 py-2 h-11"
+                        value={passenger.title}
+                        onChange={onPassengerChange(index, "title")}
+                      >
+                        <option value="mr">Mr</option>
+                        <option value="mrs">Mrs</option>
+                        <option value="ms">Ms</option>
+                        <option value="miss">Miss</option>
+                        <option value="dr">Dr</option>
+                      </select>
+                    </div>
+                    <div className="flex flex-col">
+                      <label htmlFor={`given-${index}`} className="text-sm text-muted-foreground mb-1">
+                        Given name
+                      </label>
+                      <input
+                        id={`given-${index}`}
+                        className="border border-input bg-background rounded-md px-3 py-2 h-11"
+                        value={passenger.given_name}
+                        onChange={onPassengerChange(index, "given_name")}
+                        required
+                      />
+                    </div>
+                    <div className="flex flex-col">
+                      <label htmlFor={`family-${index}`} className="text-sm text-muted-foreground mb-1">
+                        Family name
+                      </label>
+                      <input
+                        id={`family-${index}`}
+                        className="border border-input bg-background rounded-md px-3 py-2 h-11"
+                        value={passenger.family_name}
+                        onChange={onPassengerChange(index, "family_name")}
+                        required
+                      />
+                    </div>
+                    <div className="flex flex-col">
+                      <label htmlFor={`dob-${index}`} className="text-sm text-muted-foreground mb-1">
+                        Date of birth
+                      </label>
+                      <input
+                        id={`dob-${index}`}
+                        type="date"
+                        className="border border-input bg-background rounded-md px-3 py-2 h-11"
+                        value={passenger.born_on}
+                        onChange={onPassengerChange(index, "born_on")}
+                        required
+                      />
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="flex flex-col">
+                      <label htmlFor={`email-${index}`} className="text-sm text-muted-foreground mb-1">
+                        Email
+                      </label>
+                      <input
+                        id={`email-${index}`}
+                        type="email"
+                        className="border border-input bg-background rounded-md px-3 py-2 h-11"
+                        value={passenger.email}
+                        onChange={onPassengerChange(index, "email")}
+                        required
+                      />
+                    </div>
+                    <div className="flex flex-col">
+                      <label htmlFor={`phone-${index}`} className="text-sm text-muted-foreground mb-1">
+                        Phone number
+                      </label>
+                      <input
+                        id={`phone-${index}`}
+                        type="tel"
+                        className="border border-input bg-background rounded-md px-3 py-2 h-11"
+                        value={passenger.phone_number}
+                        onChange={onPassengerChange(index, "phone_number")}
+                        required
+                      />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="space-y-3">
+              <h2 className="text-lg font-semibold">Primary contact</h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="flex flex-col">
+                  <label htmlFor="contact-email" className="text-sm text-muted-foreground mb-1">
+                    Contact email
+                  </label>
+                  <input
+                    id="contact-email"
+                    type="email"
+                    className="border border-input bg-background rounded-md px-3 py-2 h-11"
+                    value={contact.email}
+                    onChange={event => setContact(prev => ({...prev, email: event.currentTarget.value}))}
+                    required
+                  />
+                </div>
+                <div className="flex flex-col">
+                  <label htmlFor="contact-phone" className="text-sm text-muted-foreground mb-1">
+                    Contact phone number
+                  </label>
+                  <input
+                    id="contact-phone"
+                    type="tel"
+                    className="border border-input bg-background rounded-md px-3 py-2 h-11"
+                    value={contact.phone_number}
+                    onChange={event =>
+                      setContact(prev => ({...prev, phone_number: event.currentTarget.value}))
+                    }
+                    required
+                  />
+                </div>
+              </div>
+            </div>
+
+            {bookingError && (
+              <div className="border border-destructive/50 bg-destructive/10 text-destructive rounded-lg p-4">
+                {bookingError}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="w-full bg-primary text-primary-foreground rounded-md h-12 flex items-center justify-center font-semibold text-lg disabled:bg-primary/70"
+            >
+              {booking ? "Confirming…" : "Confirm & book"}
+            </button>
+          </form>
+
+          {bookingResult && (
+            <div className="border border-border rounded-xl bg-muted/20 p-6 space-y-3">
+              <h2 className="text-xl font-semibold">Booking confirmed</h2>
+              <p className="text-muted-foreground text-sm">
+                Your Duffel order is confirmed. Share this booking reference with the traveller and keep an
+                eye on your inbox for e-ticket documents.
+              </p>
+              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+                <div>
+                  <dt className="font-medium text-foreground">Order ID</dt>
+                  <dd className="text-muted-foreground">{bookingResult.order_id}</dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-foreground">Booking reference</dt>
+                  <dd className="text-muted-foreground">{bookingResult.booking_reference}</dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-foreground">Status</dt>
+                  <dd className="text-muted-foreground">{bookingResult.status}</dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-foreground">Charged to airline</dt>
+                  <dd className="text-muted-foreground">
+                    {bookingResult.pricing?.base_total_amount} {bookingResult.pricing?.currency}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-foreground">Total collected</dt>
+                  <dd className="text-muted-foreground">
+                    {bookingResult.pricing?.display_total_amount} {bookingResult.pricing?.currency}
+                  </dd>
+                </div>
+              </dl>
+              {Array.isArray(bookingResult.documents) && bookingResult.documents.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-medium text-foreground">Travel documents</h3>
+                  <ul className="mt-2 space-y-1 text-sm text-muted-foreground">
+                    {bookingResult.documents.map((doc: any) => (
+                      <li key={doc.id ?? doc.unique_identifier}>
+                        {doc.type?.toUpperCase()}: {doc.unique_identifier ?? "Awaiting issuance"}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+
+          {loadingOffer && !offer && (
+            <div className="border border-border rounded-xl bg-card shadow animate-pulse h-48" />
+          )}
+        </section>
       </main>
       <Footer />
     </div>

--- a/src/app/travel/page.tsx
+++ b/src/app/travel/page.tsx
@@ -1,42 +1,103 @@
-
 "use client";
-import { useState } from "react";
+
+import Link from "next/link";
+import {FormEvent, useMemo, useState} from "react";
 import Header from "@/components/header";
 import Footer from "@/components/footer";
+import type {OfferSummary, SegmentSummary} from "@/lib/travel";
 
-export default function Home() {
-  const [offers, setOffers] = useState<any[]>([]);
+type SearchState = {
+  origin: string;
+  destination: string;
+  departureDate: string;
+  returnDate?: string | null;
+  adults: number;
+  cabinClass: string;
+};
+
+const formatter = new Intl.DateTimeFormat("en", {
+  weekday: "short",
+  month: "short",
+  day: "2-digit",
+  hour: "numeric",
+  minute: "numeric",
+});
+
+function formatDate(value?: string | null) {
+  if (!value) return "";
+  try {
+    return formatter.format(new Date(value));
+  } catch (error) {
+    return value ?? "";
+  }
+}
+
+function formatDuration(duration?: string | null) {
+  if (!duration) return "";
+  const match = duration.match(/PT(?:(\d+)H)?(?:(\d+)M)?/);
+  if (!match) return duration;
+  const [, hours, minutes] = match;
+  const parts = [] as string[];
+  if (hours) parts.push(`${hours}h`);
+  if (minutes) parts.push(`${minutes}m`);
+  return parts.join(" ");
+}
+
+function segmentKey(segment: SegmentSummary, index: number) {
+  return segment.id || `${segment.marketing_flight}-${index}`;
+}
+
+export default function TravelPage() {
+  const [offers, setOffers] = useState<OfferSummary[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [lastSearch, setLastSearch] = useState<SearchState | null>(null);
 
-  async function onSearch(formData: FormData) {
+  const resultsTitle = useMemo(() => {
+    if (!lastSearch) return null;
+    const {origin, destination, departureDate, returnDate, adults} = lastSearch;
+    const travellers = adults === 1 ? "1 traveller" : `${adults} travellers`;
+    const outbound = new Date(departureDate).toLocaleDateString();
+    const inbound = returnDate ? new Date(returnDate).toLocaleDateString() : null;
+    return inbound
+      ? `${origin} → ${destination} (${outbound}) · Return on ${inbound} · ${travellers}`
+      : `${origin} → ${destination} (${outbound}) · ${travellers}`;
+  }, [lastSearch]);
+
+  async function onSearch(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const payload: SearchState = {
+      origin: String(formData.get("origin") ?? "").toUpperCase(),
+      destination: String(formData.get("destination") ?? "").toUpperCase(),
+      departureDate: String(formData.get("departureDate") ?? ""),
+      returnDate: (formData.get("returnDate") as string) || null,
+      adults: Math.max(1, Number(formData.get("adults") ?? 1)),
+      cabinClass: String(formData.get("cabinClass") ?? "economy"),
+    };
+
     setLoading(true);
     setError(null);
-    const body = {
-      origin: formData.get("origin"),
-      destination: formData.get("destination"),
-      departure_date: formData.get("departure_date"),
-      return_date: formData.get("return_date") || undefined,
-      adults: Number(formData.get("adults") || 1),
-      cabin_class: "economy",
-    };
+    setOffers([]);
+
     try {
-      const r = await fetch(process.env.NEXT_PUBLIC_API_URL + "/api/search", {
+      const response = await fetch("/api/travel/search", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify(payload),
       });
-      if (!r.ok) {
-        throw new Error('Search request failed. Please check the API server.');
+
+      if (!response.ok) {
+        const {error: message} = await response.json().catch(() => ({error: ""}));
+        throw new Error(message || "Search request failed. Please try again.");
       }
-      const data = await r.json();
-      if (data.error) {
-        throw new Error(data.error);
-      }
-      setOffers(data.offers || []);
-    } catch (error: any) {
-      console.error(error);
-      setError(error.message || "An unknown error occurred.");
+
+      const data = await response.json();
+      setOffers(data.offers ?? []);
+      setLastSearch({...payload, adults: data.passengers ?? payload.adults});
+    } catch (err: any) {
+      console.error(err);
+      setError(err?.message ?? "We couldn’t reach the flight search service.");
     } finally {
       setLoading(false);
     }
@@ -45,45 +106,219 @@ export default function Home() {
   return (
     <div className="flex flex-col min-h-screen bg-background">
       <Header />
-      <main className="p-6 max-w-3xl mx-auto pt-24 w-full">
-        <div className="space-y-8">
-            <div>
-                <h1 className="text-3xl font-headline font-bold mb-2 text-center">Search for Flights</h1>
-                <p className="text-muted-foreground text-center">Find the best flights for your journey to your new school.</p>
+      <main className="px-6 pb-24 pt-24 w-full">
+        <section className="max-w-5xl mx-auto space-y-10">
+          <div className="text-center space-y-3">
+            <h1 className="text-4xl font-headline font-bold">Plan your journey</h1>
+            <p className="text-muted-foreground text-lg">
+              Search real-time Duffel flights, add our $75 travel concierge fee per traveller, and
+              lock in your seat in just a few clicks.
+            </p>
+          </div>
+
+          <form
+            onSubmit={onSearch}
+            className="grid grid-cols-1 lg:grid-cols-6 gap-4 border p-6 rounded-xl bg-card shadow-xl"
+          >
+            <div className="lg:col-span-2 flex flex-col">
+              <label htmlFor="origin" className="text-sm font-medium text-muted-foreground mb-1">
+                Origin airport
+              </label>
+              <input
+                id="origin"
+                name="origin"
+                placeholder="e.g. YYZ"
+                className="border border-input bg-background rounded-md px-3 py-2 h-12 uppercase"
+                required
+              />
             </div>
-          <form action={onSearch} className="grid grid-cols-1 sm:grid-cols-2 gap-4 border p-6 rounded-lg bg-card shadow-lg">
-            <input name="origin" placeholder="Origin (e.g., YYZ)" className="border p-2 rounded-md h-12" required />
-            <input name="destination" placeholder="Destination (e.g., NBO)" className="border p-2 rounded-md h-12" required />
+
+            <div className="lg:col-span-2 flex flex-col">
+              <label
+                htmlFor="destination"
+                className="text-sm font-medium text-muted-foreground mb-1"
+              >
+                Destination airport
+              </label>
+              <input
+                id="destination"
+                name="destination"
+                placeholder="e.g. NBO"
+                className="border border-input bg-background rounded-md px-3 py-2 h-12 uppercase"
+                required
+              />
+            </div>
+
             <div className="flex flex-col">
-              <label htmlFor="departure_date" className="text-sm font-medium text-muted-foreground mb-1">Departure Date</label>
-              <input id="departure_date" name="departure_date" type="date" className="border p-2 rounded-md h-12" required />
+              <label
+                htmlFor="departureDate"
+                className="text-sm font-medium text-muted-foreground mb-1"
+              >
+                Departure date
+              </label>
+              <input
+                id="departureDate"
+                name="departureDate"
+                type="date"
+                className="border border-input bg-background rounded-md px-3 py-2 h-12"
+                required
+              />
             </div>
+
             <div className="flex flex-col">
-              <label htmlFor="return_date" className="text-sm font-medium text-muted-foreground mb-1">Return Date</label>
-              <input id="return_date" name="return_date" type="date" className="border p-2 rounded-md h-12" />
+              <label htmlFor="returnDate" className="text-sm font-medium text-muted-foreground mb-1">
+                Return date (optional)
+              </label>
+              <input
+                id="returnDate"
+                name="returnDate"
+                type="date"
+                className="border border-input bg-background rounded-md px-3 py-2 h-12"
+              />
             </div>
+
             <div className="flex flex-col">
-              <label htmlFor="adults" className="text-sm font-medium text-muted-foreground mb-1">Adults</label>
-              <input id="adults" name="adults" type="number" min={1} defaultValue={1} className="border p-2 rounded-md h-12" />
+              <label htmlFor="adults" className="text-sm font-medium text-muted-foreground mb-1">
+                Travellers
+              </label>
+              <input
+                id="adults"
+                name="adults"
+                type="number"
+                min={1}
+                defaultValue={1}
+                className="border border-input bg-background rounded-md px-3 py-2 h-12"
+              />
             </div>
-            <button disabled={loading} className="col-span-1 sm:col-span-2 bg-primary text-primary-foreground p-3 rounded-md h-12 flex items-center justify-center font-semibold text-lg disabled:bg-primary/70">
-              {loading ? "Searching…" : "Search"}
+
+            <div className="flex flex-col">
+              <label htmlFor="cabinClass" className="text-sm font-medium text-muted-foreground mb-1">
+                Cabin
+              </label>
+              <select
+                id="cabinClass"
+                name="cabinClass"
+                className="border border-input bg-background rounded-md px-3 py-2 h-12"
+                defaultValue="economy"
+              >
+                <option value="economy">Economy</option>
+                <option value="premium_economy">Premium Economy</option>
+                <option value="business">Business</option>
+                <option value="first">First</option>
+              </select>
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="lg:col-span-6 bg-primary text-primary-foreground rounded-md h-12 flex items-center justify-center font-semibold text-lg transition hover:bg-primary/90 disabled:bg-primary/70"
+            >
+              {loading ? "Searching flights…" : "Search flights"}
             </button>
           </form>
 
-          {error && <div className="text-red-500 text-center p-4 border border-red-500 bg-red-50 rounded-md">{error}</div>}
+          {error && (
+            <div className="border border-destructive/50 bg-destructive/10 text-destructive rounded-lg p-4">
+              {error}
+            </div>
+          )}
 
-          <div className="mt-8 space-y-4">
-            {offers.map((o) => (
-              <div key={o.id} className="border p-4 rounded-lg bg-card shadow-md">
-                <div className="font-bold text-lg text-primary">{o.slices[0].origin} → {o.slices[0].destination}</div>
-                <div className="text-muted-foreground">{o.slices[0].segments[0].carrier_name}</div>
-                <div className="text-xl font-headline font-bold mt-2">Total (with $75/ticket): {o.pricing.display_total_amount} {o.pricing.currency}</div>
-                <a href={`/checkout?offer=${o.id}`} className="underline text-primary font-semibold mt-2 inline-block">Book Now</a>
+          {resultsTitle && !loading && (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <h2 className="text-2xl font-headline font-semibold">Available itineraries</h2>
+                <span className="text-sm text-muted-foreground">{resultsTitle}</span>
               </div>
+              <p className="text-sm text-muted-foreground">
+                Pricing includes airline fare plus our $75 student concierge fee per traveller. Pay the
+                airline via Duffel, we keep the support fee.
+              </p>
+            </div>
+          )}
+
+          <div className="grid gap-6">
+            {loading && (
+              <div className="border border-border rounded-xl bg-card shadow animate-pulse h-40" />
+            )}
+
+            {!loading && offers.length === 0 && lastSearch && !error && (
+              <div className="border border-dashed border-border rounded-xl bg-card p-8 text-center text-muted-foreground">
+                We couldn’t find flights for that search. Try adjusting your dates or airports.
+              </div>
+            )}
+
+            {offers.map(offer => (
+              <article
+                key={offer.id}
+                className="border border-border rounded-xl bg-card shadow-md p-6 space-y-5"
+              >
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-sm uppercase tracking-wide text-muted-foreground">
+                      {offer.owner?.iata_code}
+                    </p>
+                    <h3 className="text-xl font-semibold">{offer.owner?.name ?? "Airline option"}</h3>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm text-muted-foreground">Total including fees</p>
+                    <p className="text-2xl font-headline font-bold">
+                      {offer.pricing.display_total_amount} {offer.pricing.currency}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Base fare {offer.pricing.base_total_amount} + {offer.pricing.markup_total} concierge fee
+                    </p>
+                  </div>
+                </div>
+
+                <div className="space-y-4">
+                  {offer.slices.map(slice => (
+                    <div key={slice.id} className="rounded-lg border border-border/60 bg-muted/20 p-4">
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <p className="font-medium">
+                          {slice.origin} → {slice.destination}
+                        </p>
+                        <span className="text-sm text-muted-foreground">
+                          {formatDuration(slice.duration)}
+                        </span>
+                      </div>
+                      <ol className="mt-3 space-y-3">
+                        {slice.segments.map((segment, index) => (
+                          <li key={segmentKey(segment, index)} className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                            <div>
+                              <p className="font-semibold">
+                                {formatDate(segment.departing_at)} → {formatDate(segment.arriving_at)}
+                              </p>
+                              <p className="text-sm text-muted-foreground">
+                                {segment.origin} to {segment.destination}
+                              </p>
+                            </div>
+                            <div className="text-sm text-muted-foreground text-right">
+                              <p>{segment.carrier_name}</p>
+                              {segment.marketing_flight && <p>{segment.marketing_flight}</p>}
+                            </div>
+                          </li>
+                        ))}
+                      </ol>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                  <p className="text-sm text-muted-foreground">
+                    Flexible changes and baggage allowances depend on the airline. Review on the next
+                    step before checkout.
+                  </p>
+                  <Link
+                    href={`/checkout?offer=${offer.id}&pax=${lastSearch?.adults ?? 1}`}
+                    className="inline-flex items-center justify-center rounded-md bg-primary px-5 py-2 text-primary-foreground font-semibold hover:bg-primary/90"
+                  >
+                    Select & checkout
+                  </Link>
+                </div>
+              </article>
             ))}
           </div>
-        </div>
+        </section>
       </main>
       <Footer />
     </div>

--- a/src/lib/duffel.ts
+++ b/src/lib/duffel.ts
@@ -1,0 +1,16 @@
+import {Duffel} from '@duffel/api';
+
+let cachedClient: Duffel | null = null;
+
+export function getDuffelClient() {
+  const token = process.env.DUFFEL_ACCESS_TOKEN;
+  if (!token) {
+    throw new Error('DUFFEL_ACCESS_TOKEN is not configured.');
+  }
+
+  if (!cachedClient) {
+    cachedClient = new Duffel({token});
+  }
+
+  return cachedClient;
+}

--- a/src/lib/travel.ts
+++ b/src/lib/travel.ts
@@ -1,0 +1,102 @@
+const MARKUP_PER_TICKET = 75;
+
+type PassengerCount = number;
+
+type Offer = any;
+
+type Pricing = {
+  currency: string;
+  base_total_amount: string;
+  markup_per_ticket: string;
+  tickets: number;
+  markup_total: string;
+  display_total_amount: string;
+};
+
+type SegmentSummary = {
+  id: string;
+  marketing_flight?: string | null;
+  carrier_name?: string | null;
+  departing_at?: string | null;
+  arriving_at?: string | null;
+  origin?: string | null;
+  destination?: string | null;
+  aircraft_name?: string | null;
+};
+
+type SliceSummary = {
+  id: string;
+  origin?: string | null;
+  destination?: string | null;
+  duration?: string | null;
+  segments: SegmentSummary[];
+};
+
+type OwnerSummary = {
+  name?: string | null;
+  iata_code?: string | null;
+  logo_symbol_url?: string | null;
+};
+
+type OfferSummary = {
+  id: string;
+  slices: SliceSummary[];
+  owner: OwnerSummary;
+  pricing: Pricing;
+  conditions?: any;
+};
+
+export type {OfferSummary, Pricing, SliceSummary, SegmentSummary};
+
+export function applyMarkup(offer: Offer, passengers: PassengerCount) {
+  const base = Number(offer.total_amount ?? 0);
+  const markupTotal = MARKUP_PER_TICKET * passengers;
+  const display = (base + markupTotal).toFixed(2);
+
+  return {
+    ...offer,
+    pricing: {
+      currency: offer.total_currency,
+      base_total_amount: String(offer.total_amount ?? '0.00'),
+      markup_per_ticket: MARKUP_PER_TICKET.toFixed(2),
+      tickets: passengers,
+      markup_total: markupTotal.toFixed(2),
+      display_total_amount: display,
+    } satisfies Pricing,
+  };
+}
+
+export function summariseOffer(offer: Offer, passengers: PassengerCount): OfferSummary {
+  const priced = applyMarkup(offer, passengers);
+
+  const slices: SliceSummary[] = (priced.slices ?? []).map((slice: any) => ({
+    id: slice.id,
+    origin: slice.origin?.iata_code ?? slice.origin?.name ?? null,
+    destination: slice.destination?.iata_code ?? slice.destination?.name ?? null,
+    duration: slice.duration ?? null,
+    segments: (slice.segments ?? []).map((segment: any) => ({
+      id: segment.id,
+      marketing_flight: segment.marketing_carrier?.iata_code
+        ? `${segment.marketing_carrier.iata_code}${segment.marketing_flight_number ?? ''}`
+        : null,
+      carrier_name: segment.operating_carrier?.name ?? segment.marketing_carrier?.name ?? null,
+      departing_at: segment.departing_at ?? null,
+      arriving_at: segment.arriving_at ?? null,
+      origin: segment.origin?.iata_code ?? segment.origin?.name ?? null,
+      destination: segment.destination?.iata_code ?? segment.destination?.name ?? null,
+      aircraft_name: segment.aircraft?.name ?? null,
+    })),
+  }));
+
+  return {
+    id: priced.id,
+    slices,
+    owner: {
+      name: priced.owner?.name ?? null,
+      iata_code: priced.owner?.iata_code ?? null,
+      logo_symbol_url: priced.owner?.logo_symbol_url ?? null,
+    },
+    pricing: priced.pricing,
+    conditions: priced.conditions,
+  };
+}


### PR DESCRIPTION
## Summary
- add Duffel-backed API endpoints for searching offers, retrieving offer details, and booking orders with the platform markup
- refresh the travel search page to call the new APIs, surface itinerary and pricing details, and link to checkout with traveller counts
- rebuild checkout to collect passenger/contact information, call the booking API, and display confirmation details, plus shared Duffel helpers and docs updates

## Testing
- npm run lint *(fails: command prompts to configure ESLint interactively and was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68cae9cad93483238895f04668db77e1