### PR TITLE
Refresh roadmap docs and relocate admin access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,105 @@
-# Firebase Studio
+# VisaPilot Platform
 
-This is a NextJS starter in Firebase Studio.
+VisaPilot is a full-stack platform for international students planning their studies abroad. The application combines guided consultations, curated study packages, and travel booking tools so prospective students can plan end-to-end journeys in one place.
 
-To get started, take a look at src/app/page.tsx.
+## Current MVP Highlights
 
-## Travel booking setup
+- **Flight search & booking:** Users can search Duffel's inventory, review itineraries with VisaPilot's $75 service fee automatically applied, and complete bookings using the Duffel balance model.
+- **Study package payments:** The study tiers and add-ons flow is wired to Stripe Checkout, enabling students to complete purchases from the UI.
+- **AI-powered support:** Consultation summaries, document checklists, and the AI course finder are available to guide both advisors and students.
+- **Consultation scheduling:** Students can request appointments through the site. Bookings are stored on the server and surfaced in the admin dashboard for manual follow-up.
 
-Set the Duffel access token before running the development server:
+## Launch-Critical Roadmap
 
-```bash
-export DUFFEL_ACCESS_TOKEN="duffel_live_xxx"
+These items are required before marketing the application to a wider audience:
+
+1. **Harden appointment storage** – Replace the JSON file with a persistent database (e.g., Firebase Firestore) so meetings survive restarts and scale with traffic.
+2. **Protect the admin suite** – Introduce authentication (Firebase Auth, NextAuth.js, or similar) and gate all routes under `/admin`.
+3. **Automate notifications** – Send confirmation emails (and optionally reminders) to both students and staff after bookings or payment events.
+4. **Swap placeholder content** – Finalize imagery, copywriting, and admin dashboard summaries so they reflect production messaging.
+5. **Production readiness** – Complete end-to-end QA for every flow, then deploy the Next.js frontend (Vercel) and Node/Express services (Fly.io, Render, or similar) with environment variables configured.
+
+Refer to [`ROADMAP.md`](ROADMAP.md) for detailed implementation tasks and nice-to-have enhancements.
+
+## Repository Structure
+
+```text
+src/            # Next.js application (app router)
+server/         # Express service for Duffel bookings & markup handling
+components.json # shadcn/ui registry
 ```
 
-The Travel page (`/travel`) now uses Duffel’s API to search, review, and book flights end to end.
+## Getting Started
+
+### Prerequisites
+
+- Node.js 18+
+- Yarn or npm
+
+Install dependencies:
+
+```bash
+yarn install
+# or
+npm install
+```
+
+### Environment Variables
+
+Create a `.env.local` file at the project root and set the following keys:
+
+```bash
+DUFFEL_ACCESS_TOKEN=...
+STRIPE_SECRET_KEY=...
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=...
+NEXT_PUBLIC_SITE_URL=http://localhost:9002  # optional, used in Stripe helpers
+```
+
+The Express server in `server/` also expects `DUFFEL_ACCESS_TOKEN`. Create `server/.env` if you run it locally.
+
+### Running the App Locally
+
+Start the Next.js frontend on port 9002:
+
+```bash
+yarn dev
+```
+
+Start the Duffel Express bridge in another terminal:
+
+```bash
+cd server
+npm install
+npm start
+```
+
+The travel workflow relies on both services running concurrently.
+
+### Useful Scripts
+
+- `yarn lint` – Run Next.js lint checks.
+- `yarn build` – Compile the production build.
+- `yarn typecheck` – Run TypeScript in `--noEmit` mode.
+
+## Testing & QA Checklist
+
+- Book a consultation and confirm the record appears in the admin dashboard.
+- Purchase each study package and add-on combination through Stripe Checkout.
+- Search for flights, review itineraries, and complete a booking end-to-end.
+- Validate that AI tools return relevant summaries, checklists, and course matches.
+
+## Deployment Notes
+
+- Deploy the Next.js app to Vercel (or another preferred platform) with the same environment variables configured as in development.
+- Deploy the Express Duffel bridge to a Node-compatible host such as Fly.io or Render, and point the frontend to its public URL.
+- Configure analytics and monitoring before launch to track conversions and identify regressions quickly.
+
+## Contributing
+
+1. Create a feature branch.
+2. Make changes and ensure `yarn lint` passes.
+3. Submit a pull request with a summary of changes and testing evidence.
+
+---
+
+For a detailed backlog of enhancements—AI tooling, admin automation, and internationalization plans—continue to maintain [`ROADMAP.md`](ROADMAP.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,110 +1,57 @@
-# VisaPilot: Feature Roadmap & Pre-Launch Checklist
+# VisaPilot: Launch Roadmap
 
-This document outlines the key features, improvements, and action items required to prepare the VisaPilot application for launch. It serves as our strategic guide to ensure a robust, polished, and successful product.
+This document translates the current MVP into a launch-ready product plan. Use it as the source of truth for engineering, content, and operations workstreams.
 
----
+## ✅ MVP Pillars (Complete)
 
-## 1. Core Functionality (Needs Implementation)
+- **Flight search & booking:** Duffel integration delivers full search → itinerary review → booking with the $75 VisaPilot markup.
+- **Study package payments:** Stripe Checkout is live for tiers and add-ons.
+- **AI tools:** Consultation summaries, document checklists, and the AI course finder are functioning.
+- **Appointment booking (v1):** Users can request consultations and the system persists them to the server-managed JSON store.
 
-These are the essential features that are currently placeholders and require full backend implementation.
+## 🚀 Launch Blockers (High Priority)
 
-### 1.1. Appointment Booking System
--   **Current State:** Frontend UI allows users to select a date/time and enter details. A success toast is shown.
--   **Required Implementation:**
-    -   **[ ] Backend Logic:** Create a database schema (e.g., in Firestore) to store appointment details (student name, email, date, time, status).
-    -   **[ ] Server Action:** Update the `handleBookingSubmit` function in `src/app/study/page.tsx` to save the appointment data to the database instead of just showing a toast.
-    -   **[ ] Confirmation Emails:** Integrate an email service (e.g., SendGrid, Resend) to automatically send confirmation emails to both the student and the admin/expert upon successful booking.
-    -   **[ ] Calendar Sync:** (Future Goal) Allow experts to sync their Google Calendar to manage availability dynamically.
+1. **Migrate appointments to a managed database**
+   - [ ] Replace the JSON file with Firestore (or another persistent store).
+   - [ ] Update admin pages to read/write from the database.
+   - [ ] Introduce status management (new / confirmed / completed / cancelled).
+2. **Secure the admin experience**
+   - [ ] Choose an auth provider (Firebase Auth, NextAuth.js, Clerk, etc.).
+   - [ ] Protect every route and API endpoint under `/admin`.
+   - [ ] Add role-based access for future staff users.
+3. **Automate transactional email**
+   - [ ] Send confirmation emails to students and admins for bookings and purchases.
+   - [ ] Template notifications for cancellations or reschedules.
+   - [ ] Evaluate reminder emails (24 hours before consultation).
+4. **Replace placeholder assets & copy**
+   - [ ] Swap out stock/placeholder imagery across marketing and admin pages.
+   - [ ] Refresh admin dashboard stats and labels with real data descriptions.
+   - [ ] Confirm policy pages and links point to final legal content.
+5. **Final QA & deployment**
+   - [ ] Execute end-to-end smoke tests for every flow (booking, payments, AI tools, travel search).
+   - [ ] Provision production hosting (Vercel + Fly.io/Render) and migrate environment variables.
+   - [ ] Configure monitoring, analytics, and error reporting.
 
-### 1.2. Payment Processing (Tiers & Add-Ons)
--   **Current State:** Pricing tiers are displayed, but there is no payment functionality.
--   **Required Implementation:**
-    -   **[ ] Stripe & Paystack/Flutterwave Integration:**
-        -   Set up API keys in environment variables.
-        -   Create a server action to generate payment links or checkout sessions for selected tiers/add-ons.
-        -   Build a payment confirmation page or a success modal.
-    -   **[ ] Database Tracking:** Record successful payments against a student's record or appointment.
+## 📈 Enhancements After Launch
 
-### 1.3. Travel Booking Integration
--   **Current State:** Search forms exist on the `/travel` page but are not functional.
--   **Required Implementation:**
-    -   **[ ] Flight & Accommodation API Integration:**
-        -   Choose and integrate with a travel affiliate API (e.g., Skyscanner, Kiwi, Amadeus).
-        -   Implement the search logic in a server action to call the external API.
-    -   **[ ] Display Search Results:** Create a component to display flight and accommodation search results returned from the API.
-    -   **[ ] Commission Logic:** Implement logic to track commissions earned from referred bookings.
+### Admin automation
+- [ ] CRUD for study resources with public-facing distribution.
+- [ ] Export appointments and payments as CSV or integrate with a CRM.
+- [ ] Dashboard insights powered by live metrics.
 
----
+### AI tooling
+- [ ] Persist generated summaries/checklists per student and allow edits.
+- [ ] Add version history for regenerated outputs.
+- [ ] Improve prompts with examples and domain-specific guardrails.
 
-## 2. Admin Panel Enhancements
+### Travel & monetization
+- [ ] Expand beyond flights to include accommodations or ground transport.
+- [ ] Track commissions/earnings inside the admin dashboard.
+- [ ] Offer bundles that combine travel, study packages, and consultations.
 
-Making the admin dashboard a powerful tool for managing the business.
+### Experience polish
+- [ ] Perform a responsive design audit across devices.
+- [ ] Improve accessibility (ARIA, keyboard nav, focus states).
+- [ ] Localize key flows for additional markets.
 
-### 2.1. Dynamic Data
--   **Current State:** All data in the admin panel is static (hard-coded arrays).
--   **Required Implementation:**
-    -   **[ ] Appointments:** Fetch and display real appointment data from the database on the `/admin/appointments` page.
-    -   **[ ] Travel Bookings:** Fetch and display travel booking/commission data on the `/admin/travel` page.
-    -   **[ ] Dashboard Metrics:** Update the main dashboard (`/admin`) to calculate and display real-time metrics (Total Revenue, Upcoming Appointments, etc.) from the database.
-    -   **[ ] Actionable Menus:** Implement functionality for the dropdown menus on the appointments table (e.g., "View Details", "Generate Summary").
-
-### 2.2. Content Management
--   **Current State:** The "Study & Visa Administration" page (`/admin/study`) shows a static list.
--   **Required Implementation:**
-    -   **[ ] CRUD for Resources:** Build a form for admins to add, edit, and delete guides and checklists.
-    -   **[ ] Dynamic Resource Display:** Create a public-facing "Resources" page where users can view the guides and checklists managed by the admin.
-
----
-
-## 3. AI Feature Enhancements
-
-Improving the intelligence and usability of the AI-powered tools.
-
-### 3.1. Saving & Editing Generated Content
--   **Current State:** AI-generated summaries and checklists are displayed once and then disappear on page reload.
--   **Required Implementation:**
-    -   **[ ] Save to Database:** Add a "Save" button to store the generated text in the database, associated with a specific student or appointment.
-    -   **[ ] Edit & Review:** Allow experts to edit the generated text in the text area and save the changes.
-    -   **[ ] History:** (Future Goal) Keep a history of generated content for each student.
-
-### 3.2. Refining AI Prompts
--   **Current State:** Prompts are functional but could be more robust.
--   **Required Implementation:**
-    -   **[ ] Contextual Refinement:** Iteratively test and refine the prompts in `src/ai/flows/` to handle a wider range of inputs and produce more accurate, well-formatted outputs.
-    -   **[ ] Example-Driven Prompts:** Consider adding few-shot examples to the prompts to guide the model's output structure more effectively.
-
----
-
-## 4. UI/UX Polish & Final Touches
-
-Final improvements for a professional, launch-ready application.
-
-### 4.1. Responsive Design Review
--   **[ ] Thorough Testing:** Test every page and component on various screen sizes (mobile, tablet, desktop) to ensure a seamless experience. Pay close attention to forms, tables, and dialogs.
-
-### 4.2. Accessibility (a11y)
--   **[ ] ARIA Attributes:** Review all interactive elements (buttons, inputs, menus) and ensure they have appropriate ARIA labels and roles.
--   **[ ] Keyboard Navigation:** Ensure the entire application is navigable and usable with only a keyboard.
-
-### 4.3. Authentication
--   **[ ] Secure Admin Login:** Implement a secure authentication system (e.g., using NextAuth.js or Firebase Auth) for the entire `/admin` section. The current panel is publicly accessible.
-
-### 4.4. Placeholder Content
--   **[ ] Images:** Replace all placeholder images from `picsum.photos` with professional, relevant imagery from a service like Unsplash or with custom graphics.
--   **[ ] Text:** Review all copy, including footer links (Terms of Service, Privacy Policy), and ensure it is final.
-
----
-
-## 5. Pre-Launch Checklist
-
-The final steps before going live.
-
--   [ ] **Final End-to-End Testing:**
-    -   [ ] User books an appointment.
-    -   [ ] Admin sees the appointment.
-    -   [ ] Payment is processed successfully.
-    -   [ ] AI tools are used on an appointment.
-    -   [ ] User successfully searches for a flight/hotel.
--   [ ] **Environment Variables:** Ensure all API keys and secrets are correctly set up in the production environment.
--   [ ] **Domain & Hosting:** Configure the custom domain and ensure the production deployment is stable.
--   [ ] **Analytics:** Integrate an analytics tool (e.g., Vercel Analytics, Google Analytics) to monitor user behavior.
+Maintain this roadmap collaboratively—update statuses after each milestone so the team always knows what is left before the public launch.

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link';
+import { LayoutDashboard } from 'lucide-react';
+
 import { VisaPilotIcon } from './icons';
 
 export default function Footer() {
@@ -15,11 +17,19 @@ export default function Footer() {
             &copy; {currentYear} VisaPilot. All rights reserved.
           </p>
           <div className="flex items-center gap-4">
-            <Link href="#" className="text-sm text-muted-foreground hover:text-primary">
+            <Link href="#" className="text-sm text-muted-foreground hover:text-primary transition-colors">
               Terms of Service
             </Link>
-            <Link href="#" className="text-sm text-muted-foreground hover:text-primary">
+            <Link href="#" className="text-sm text-muted-foreground hover:text-primary transition-colors">
               Privacy Policy
+            </Link>
+            <Link
+              href="/admin"
+              aria-label="Admin dashboard"
+              className="text-muted-foreground hover:text-primary transition-colors"
+            >
+              <LayoutDashboard className="h-5 w-5" />
+              <span className="sr-only">Admin dashboard</span>
             </Link>
           </div>
         </div>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { VisaPilotIcon } from './icons';
-import { ArrowRight } from 'lucide-react';
 
 export default function Header() {
   return (
@@ -18,17 +17,14 @@ export default function Header() {
           <Link href="/travel" className="text-sm font-medium hover:text-primary transition-colors">
             Travel
           </Link>
-           <Link href="/#services" className="text-sm font-medium hover:text-primary transition-colors">
+          <Link href="/#services" className="text-sm font-medium hover:text-primary transition-colors">
             Services
           </Link>
         </nav>
         <div className="flex items-center gap-2">
-           <Button variant="ghost" asChild>
-             <Link href="/admin">Admin Panel</Link>
-           </Button>
-           <Button asChild>
-             <Link href="/study#appointments">Book Consultation</Link>
-           </Button>
+          <Button asChild>
+            <Link href="/study#appointments">Book Consultation</Link>
+          </Button>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- move the Admin dashboard entry from the header into the footer as a subtle icon link
- rewrite the README with MVP highlights, setup steps, and deployment guidance
- refresh the roadmap to outline completed pillars, launch blockers, and post-launch enhancements

## Testing
- yarn lint *(fails: Next.js lint wizard prompts for configuration and would modify the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cc354524cc8323afacd144f75d4d9e