### PR TITLE
Simplify admin authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ FIREBASE_APPOINTMENTS_COLLECTION=appointments
 FIREBASE_ORDERS_COLLECTION=orders
 
 # Admin auth
-ADMIN_ALLOWED_UID=1Z7boubvwJTwlZn89mWuwQuiZnr1
+ADMIN_ALLOWED_EMAIL=admin@example.com
 ADMIN_SHARED_SECRET=change-me
 
 # Email (optional)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ NEXT_PUBLIC_SITE_URL=http://localhost:9002  # optional, used in Stripe helpers
 FIREBASE_ADMIN_PROJECT_ID=...
 FIREBASE_ADMIN_CLIENT_EMAIL=...
 FIREBASE_ADMIN_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
-ADMIN_ALLOWED_UID=...  # Firebase UID for the primary administrator
 ```
 
 The Express server in `server/` also expects `DUFFEL_ACCESS_TOKEN`. Create `server/.env` if you run it locally.
@@ -64,11 +63,11 @@ The Express server in `server/` also expects `DUFFEL_ACCESS_TOKEN`. Create `serv
 ### Admin access & notifications
 
 - `ADMIN_ALLOWED_EMAIL` (optional) – Email address that is allowed to access the admin panel. Defaults to `anthonyluci69@gmail.com`.
-- `ADMIN_SHARED_SECRET` (optional) – Shared passphrase that must be provided during admin login. Defaults to `1Z7boubvwJTwlZn89mWuwQuiZnr1`.
+- `ADMIN_SHARED_SECRET` (optional) – Shared passphrase required during admin login. Defaults to `change-me`; update this in production.
 - `TEAM_NOTIFICATIONS_EMAIL` (optional) – Additional address that should receive operational emails. MapleLeed always copies `anthonyluci69@gmail.com`.
 - `EMAIL_FROM_ADDRESS` – Customise the sender identity for transactional email.
 
-The MapleLeed admin can now authenticate with their Firebase credentials plus the shared secret `1Z7boubvwJTwlZn89mWuwQuiZnr1`. All bookings, invoices, travel orders, and incident alerts are automatically delivered to `anthonyluci69@gmail.com`.
+Admin access now relies on matching the configured email and shared secret—no Firebase client configuration is required for sign-in. All bookings, invoices, travel orders, and incident alerts are automatically delivered to `anthonyluci69@gmail.com`.
 
 ### Running the App Locally
 

--- a/src/app/admin/(auth)/login/page.tsx
+++ b/src/app/admin/(auth)/login/page.tsx
@@ -4,10 +4,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { signInWithEmailAndPassword, getAuth } from 'firebase/auth';
 import { Loader2 } from 'lucide-react';
-
-import { app } from '@/lib/firebase';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -35,14 +32,10 @@ export default function AdminLoginPage() {
     }
 
     try {
-      const auth = getAuth(app);
-      const credentials = await signInWithEmailAndPassword(auth, email, password);
-      const idToken = await credentials.user.getIdToken();
-
       const response = await fetch('/api/admin/session', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ idToken }),
+        body: JSON.stringify({ email, password }),
       });
 
       if (!response.ok) {
@@ -51,9 +44,9 @@ export default function AdminLoginPage() {
       }
 
       router.replace('/admin');
-    } catch (authError: any) {
-      console.error('Admin login failed', authError);
-      const message = authError?.message ?? 'Unable to sign in. Check your credentials and try again.';
+    } catch (loginError: unknown) {
+      console.error('Admin login failed', loginError);
+      const message = loginError instanceof Error ? loginError.message : 'Unable to sign in. Check your credentials and try again.';
       setError(message);
     } finally {
       setSubmitting(false);

--- a/src/app/api/admin/session/route.ts
+++ b/src/app/api/admin/session/route.ts
@@ -3,48 +3,42 @@ import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
-import { ADMIN_SESSION_COOKIE } from '@/lib/auth';
-import { getFirebaseAdminAuth } from '@/lib/firebase-admin';
+import { ADMIN_SESSION_COOKIE, ADMIN_SESSION_MAX_AGE, createAdminSessionToken } from '@/lib/auth';
 import { serverEnv } from '@/lib/env/server';
 
 const bodySchema = z.object({
-  idToken: z.string().min(10),
+  email: z.string().email(),
+  password: z.string().min(1),
 });
-
-const SESSION_EXPIRY_MS = 1000 * 60 * 60 * 24 * 5; // 5 days
 
 export async function POST(request: Request) {
   try {
     const payload = await request.json();
-    const { idToken } = bodySchema.parse(payload);
-
-    const auth = getFirebaseAdminAuth();
-    const decoded = await auth.verifyIdToken(idToken, true);
+    const { email, password } = bodySchema.parse(payload);
 
     const allowedEmail = serverEnv.ADMIN_ALLOWED_EMAIL.toLowerCase();
-    const isAllowedUid = decoded.uid === serverEnv.ADMIN_ALLOWED_UID;
-    const isAllowedEmail = decoded.email?.toLowerCase() === allowedEmail;
+    const providedEmail = email.toLowerCase();
 
-    if (!isAllowedUid && !isAllowedEmail) {
-      return NextResponse.json({ error: 'You do not have admin access.' }, { status: 403 });
+    if (allowedEmail !== providedEmail || password !== serverEnv.ADMIN_SHARED_SECRET) {
+      return NextResponse.json({ error: 'Invalid admin credentials.' }, { status: 401 });
     }
 
-    const sessionCookie = await auth.createSessionCookie(idToken, { expiresIn: SESSION_EXPIRY_MS });
+    const { token } = createAdminSessionToken();
     const secure = serverEnv.NODE_ENV === 'production';
 
     const response = NextResponse.json({ success: true });
     response.cookies.set({
       name: ADMIN_SESSION_COOKIE,
-      value: sessionCookie,
+      value: token,
       httpOnly: true,
       sameSite: 'strict',
       secure,
       path: '/',
-      maxAge: SESSION_EXPIRY_MS / 1000,
+      maxAge: ADMIN_SESSION_MAX_AGE,
     });
 
     return response;
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Failed to create admin session', error);
     const message = error instanceof z.ZodError ? 'Invalid request payload.' : 'Authentication failed.';
     return NextResponse.json({ error: message }, { status: 400 });

--- a/src/hooks/use-marketing-assets.ts
+++ b/src/hooks/use-marketing-assets.ts
@@ -1,9 +1,9 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { getDownloadURL, listAll, ref } from 'firebase/storage';
-import { getStorage } from 'firebase/storage';
-import { app } from '@/lib/firebase';
+import { getDownloadURL, listAll, ref, getStorage } from 'firebase/storage';
+
+import { getFirebaseApp, isFirebaseClientConfigured } from '@/lib/firebase';
 import { DEFAULT_MARKETING_ASSETS, type MarketingAssets } from '@/lib/marketing-assets';
 
 const dedupe = (values: string[]) => Array.from(new Set(values.filter(Boolean)));
@@ -54,7 +54,15 @@ export function useMarketingAssets(fallback: MarketingAssets = DEFAULT_MARKETING
       setLoading(true);
 
       try {
-        const storage = getStorage(app);
+        if (!isFirebaseClientConfigured()) {
+          if (!cancelled) {
+            setAssets(fallback);
+            setError(null);
+          }
+          return;
+        }
+
+        const storage = getStorage(getFirebaseApp());
         const rootRef = ref(storage, 'marketing');
         const rootList = await listAll(rootRef);
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,11 +1,17 @@
 
+import { createHmac, timingSafeEqual } from 'crypto';
+
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-import { getFirebaseAdminAuth } from './firebase-admin';
 import { serverEnv } from './env/server';
 
 export const ADMIN_SESSION_COOKIE = 'admin_session';
+export const ADMIN_SESSION_MAX_AGE = 60 * 60 * 24 * 5; // 5 days
+
+type SignedSession = {
+  expiresAt: number;
+};
 
 export type AdminSession = {
   uid: string;
@@ -13,6 +19,54 @@ export type AdminSession = {
   name?: string | null;
   picture?: string | null;
 };
+
+const SESSION_EXPIRY_MS = ADMIN_SESSION_MAX_AGE * 1000;
+
+function signSessionPayload(expiresAt: number) {
+  const payload = `${serverEnv.ADMIN_ALLOWED_EMAIL.toLowerCase()}:${expiresAt}`;
+  return createHmac('sha256', serverEnv.ADMIN_SHARED_SECRET).update(payload).digest('base64url');
+}
+
+export function createAdminSessionToken() {
+  const expiresAt = Date.now() + SESSION_EXPIRY_MS;
+  const signature = signSessionPayload(expiresAt);
+  const token = `${expiresAt}.${signature}`;
+
+  return { token, expiresAt } as const;
+}
+
+function decodeSignedSession(value: string): SignedSession | null {
+  const [expiresAtRaw, providedSignature] = value.split('.');
+
+  if (!expiresAtRaw || !providedSignature) {
+    return null;
+  }
+
+  const expiresAt = Number.parseInt(expiresAtRaw, 10);
+
+  if (!Number.isFinite(expiresAt)) {
+    return null;
+  }
+
+  try {
+    const expectedSignature = signSessionPayload(expiresAt);
+    const expectedBuffer = Buffer.from(expectedSignature, 'base64url');
+    const providedBuffer = Buffer.from(providedSignature, 'base64url');
+
+    if (expectedBuffer.length !== providedBuffer.length) {
+      return null;
+    }
+
+    if (!timingSafeEqual(expectedBuffer, providedBuffer)) {
+      return null;
+    }
+
+    return { expiresAt };
+  } catch (error) {
+    console.warn('Failed to decode admin session cookie', error);
+    return null;
+  }
+}
 
 export async function verifyAdminSession(): Promise<AdminSession | null> {
   const cookieStore = await cookies();
@@ -22,27 +76,22 @@ export async function verifyAdminSession(): Promise<AdminSession | null> {
     return null;
   }
 
-  try {
-    const decoded = await getFirebaseAdminAuth().verifySessionCookie(sessionCookie.value, true);
+  const decoded = decodeSignedSession(sessionCookie.value);
 
-    const allowedEmail = serverEnv.ADMIN_ALLOWED_EMAIL.toLowerCase();
-    const isAllowedUid = decoded.uid === serverEnv.ADMIN_ALLOWED_UID;
-    const isAllowedEmail = decoded.email?.toLowerCase() === allowedEmail;
-
-    if (!isAllowedUid && !isAllowedEmail) {
-      return null;
-    }
-
-    return {
-      uid: decoded.uid,
-      email: decoded.email,
-      name: decoded.name,
-      picture: decoded.picture,
-    };
-  } catch (error) {
-    console.warn('Admin session verification failed', error);
+  if (!decoded) {
     return null;
   }
+
+  if (decoded.expiresAt <= Date.now()) {
+    return null;
+  }
+
+  return {
+    uid: 'admin',
+    email: serverEnv.ADMIN_ALLOWED_EMAIL,
+    name: 'Administrator',
+    picture: null,
+  };
 }
 
 export async function requireAdminSession(): Promise<AdminSession> {

--- a/src/lib/env/client.ts
+++ b/src/lib/env/client.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
 
 const clientSchema = z.object({
-  NEXT_PUBLIC_FIREBASE_API_KEY: z.string().min(1, 'NEXT_PUBLIC_FIREBASE_API_KEY is required'),
-  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: z.string().min(1, 'NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN is required'),
-  NEXT_PUBLIC_FIREBASE_PROJECT_ID: z.string().min(1, 'NEXT_PUBLIC_FIREBASE_PROJECT_ID is required'),
+  NEXT_PUBLIC_FIREBASE_API_KEY: z.string().min(1).optional(),
+  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: z.string().min(1).optional(),
+  NEXT_PUBLIC_FIREBASE_PROJECT_ID: z.string().min(1).optional(),
   NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: z.string().optional(),
   NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: z.string().optional(),
-  NEXT_PUBLIC_FIREBASE_APP_ID: z.string().min(1, 'NEXT_PUBLIC_FIREBASE_APP_ID is required'),
+  NEXT_PUBLIC_FIREBASE_APP_ID: z.string().min(1).optional(),
   NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: z.string().optional(),
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().min(1, 'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY is required'),
   NEXT_PUBLIC_SITE_URL: z.string().optional(),

--- a/src/lib/env/server.ts
+++ b/src/lib/env/server.ts
@@ -12,8 +12,8 @@ const serverSchema = z.object({
   FIREBASE_ADMIN_PRIVATE_KEY: z.string().min(1, 'FIREBASE_ADMIN_PRIVATE_KEY is required'),
   FIREBASE_APPOINTMENTS_COLLECTION: z.string().min(1).default('appointments'),
   FIREBASE_ORDERS_COLLECTION: z.string().min(1).default('orders'),
-  ADMIN_ALLOWED_UID: z.string().min(1, 'ADMIN_ALLOWED_UID is required'),
   ADMIN_ALLOWED_EMAIL: z.string().email().default('anthonyluci69@gmail.com'),
+  ADMIN_SHARED_SECRET: z.string().min(1, 'ADMIN_SHARED_SECRET is required').default('change-me'),
   RESEND_API_KEY: z.string().optional(),
   EMAIL_FROM_ADDRESS: z
     .string()
@@ -38,8 +38,8 @@ export const serverEnv: ServerEnv = serverSchema.parse({
   FIREBASE_ADMIN_PRIVATE_KEY: process.env.FIREBASE_ADMIN_PRIVATE_KEY,
   FIREBASE_APPOINTMENTS_COLLECTION: process.env.FIREBASE_APPOINTMENTS_COLLECTION,
   FIREBASE_ORDERS_COLLECTION: process.env.FIREBASE_ORDERS_COLLECTION,
-  ADMIN_ALLOWED_UID: process.env.ADMIN_ALLOWED_UID,
   ADMIN_ALLOWED_EMAIL: process.env.ADMIN_ALLOWED_EMAIL,
+  ADMIN_SHARED_SECRET: process.env.ADMIN_SHARED_SECRET,
   RESEND_API_KEY: process.env.RESEND_API_KEY,
   EMAIL_FROM_ADDRESS: process.env.EMAIL_FROM_ADDRESS,
   TEAM_NOTIFICATIONS_EMAIL: process.env.TEAM_NOTIFICATIONS_EMAIL,

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,10 +1,11 @@
 
-import { getApps, initializeApp, type FirebaseApp } from 'firebase/app';
+import { getApps, initializeApp, type FirebaseApp, type FirebaseOptions } from 'firebase/app';
 import { getAuth, type Auth } from 'firebase/auth';
 import { getStorage, type FirebaseStorage } from 'firebase/storage';
+
 import { clientEnv } from '@/lib/env/client';
 
-const firebaseConfig = {
+const firebaseConfig: Partial<FirebaseOptions> = {
   apiKey: clientEnv.NEXT_PUBLIC_FIREBASE_API_KEY,
   authDomain: clientEnv.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
   projectId: clientEnv.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
@@ -14,11 +15,26 @@ const firebaseConfig = {
   measurementId: clientEnv.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
+const hasFirebaseConfig = Boolean(
+  firebaseConfig.apiKey &&
+    firebaseConfig.authDomain &&
+    firebaseConfig.projectId &&
+    firebaseConfig.appId,
+);
+
 let firebaseApp: FirebaseApp | null = null;
 let firebaseStorage: FirebaseStorage | null = null;
 let firebaseAuth: Auth | null = null;
 
-function getOrInitFirebaseApp() {
+export function isFirebaseClientConfigured() {
+  return hasFirebaseConfig;
+}
+
+export function getFirebaseApp(): FirebaseApp {
+  if (!hasFirebaseConfig) {
+    throw new Error('Firebase client SDK is not configured.');
+  }
+
   if (firebaseApp) {
     return firebaseApp;
   }
@@ -26,20 +42,18 @@ function getOrInitFirebaseApp() {
   if (getApps().length > 0) {
     firebaseApp = getApps()[0];
   } else {
-    firebaseApp = initializeApp(firebaseConfig);
+    firebaseApp = initializeApp(firebaseConfig as FirebaseOptions);
   }
 
   return firebaseApp;
 }
-
-export const app = getOrInitFirebaseApp();
 
 export function getFirebaseStorage() {
   if (firebaseStorage) {
     return firebaseStorage;
   }
 
-  firebaseStorage = getStorage(getOrInitFirebaseApp());
+  firebaseStorage = getStorage(getFirebaseApp());
 
   return firebaseStorage;
 }
@@ -49,7 +63,7 @@ export function getFirebaseAuth() {
     return firebaseAuth;
   }
 
-  firebaseAuth = getAuth(getOrInitFirebaseApp());
+  firebaseAuth = getAuth(getFirebaseApp());
 
   return firebaseAuth;
 }


### PR DESCRIPTION
## Summary
- replace the Firebase-based admin login flow with a simple email + shared secret check and signed session cookie
- make the Firebase client SDK optional so marketing assets fall back gracefully when it isn’t configured
- document the new admin credentials setup and update the environment schema/example to match

## Testing
- yarn lint *(fails: existing lint errors across the repo unrelated to this change)*
- yarn typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ceba6d2cf083238696a074620aad1f